### PR TITLE
Update typings to fix typescript error

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4,5 +4,5 @@ declare module "hastebin-gen" {
     export interface HasteBinOptions {
         url?: string;
         extension?: string;
-    };
+    }
 }


### PR DESCRIPTION
This pull request removes a semicolon that caused a typescript error.

```cmd
node_modules/hastebin-paste/typings/index.d.ts:9:6 - error TS1036: Statements are not allowed in ambient 
contexts.

9     };
```